### PR TITLE
Fixes bug with RepositoryService passing itself instead of client

### DIFF
--- a/src/cmislib/atompub/binding.py
+++ b/src/cmislib/atompub/binding.py
@@ -243,7 +243,7 @@ class RepositoryService(RepositoryServiceIfc):
         for workspaceElement in workspaceElements:
             idElement = workspaceElement.getElementsByTagNameNS(CMIS_NS, 'repositoryId')
             if idElement[0].childNodes[0].data == repositoryId:
-                return AtomPubRepository(self, workspaceElement)
+                return AtomPubRepository(client, workspaceElement)
 
         raise ObjectNotFoundException(url=client.repositoryUrl)
 


### PR DESCRIPTION
The signature for the AtomRepository constructor has the first argument
being the cmis client, but the value that's passed by the
RepositoryService is itself, not the client. This commit fixes an issue
where any method of the repository objects that result in an HTTP
request fail with an AttributeError, due to the client not being
available.